### PR TITLE
feat: Add platformInfo adapter

### DIFF
--- a/packages/adapter-types/types.d.ts
+++ b/packages/adapter-types/types.d.ts
@@ -1,3 +1,10 @@
+export interface PlatformInfo {
+  name: string;
+  version?: string;
+  extra?: string;
+  userAgent?: string;
+}
+
 export interface ProgressEvent {
   loaded: number;
   percent?: number;
@@ -71,6 +78,7 @@ export interface AuthInfo {
   platform?: string;
 }
 export interface Adapters {
+  platformInfo: PlatformInfo;
   request: (url: string, options?: RequestOptions) => Promise<Response>;
   upload: (
     url: string,

--- a/packages/platform-adapters-baidu/src/index.ts
+++ b/packages/platform-adapters-baidu/src/index.ts
@@ -1,4 +1,10 @@
+import { Adapters } from "@leancloud/adapter-types";
+
 export * from "./storage";
 export * from "./websocket";
 export * from "./http";
 export * from "./auth";
+
+export const platformInfo: Adapters["platformInfo"] = {
+  name: "Baidu",
+};

--- a/packages/platform-adapters-browser/src/index.ts
+++ b/packages/platform-adapters-browser/src/index.ts
@@ -2,3 +2,7 @@ import { Adapters } from "@leancloud/adapter-types";
 export { request, upload } from "@leancloud/adapters-superagent";
 export const storage: Adapters["storage"] = window.localStorage;
 export const WebSocket: Adapters["WebSocket"] = window.WebSocket;
+
+export const platformInfo: Adapters["platformInfo"] = {
+  name: "Browser",
+};

--- a/packages/platform-adapters-node/src/index.ts
+++ b/packages/platform-adapters-node/src/index.ts
@@ -2,6 +2,10 @@ import { Adapters } from "@leancloud/adapter-types";
 import * as WS from "ws";
 import * as localStorageMemory from "localstorage-memory";
 
+export const platformInfo: Adapters["platformInfo"] = {
+  name: "Node.js",
+  version: process.versions.node,
+};
 export const WebSocket: Adapters["WebSocket"] = WS;
 export const storage: Adapters["storage"] = localStorageMemory;
 export { request, upload } from "@leancloud/adapters-superagent";

--- a/packages/platform-adapters-quickapp/src/index.ts
+++ b/packages/platform-adapters-quickapp/src/index.ts
@@ -13,6 +13,10 @@ import {
   WebSocket as QAWebSocket
 } from "@system.websocketfactory";
 
+export const platformInfo: Adapters["platformInfo"] = {
+  name: "QuickApp",
+};
+
 type Response = {
   data: Parameters<Required<Parameters<typeof fetch>[0]>["success"]>[0];
 };

--- a/packages/platform-adapters-react-native/src/index.ts
+++ b/packages/platform-adapters-react-native/src/index.ts
@@ -3,7 +3,7 @@ export * from "@leancloud/platform-adapters-browser";
 
 import LegacyStorage from "@react-native-community/async-storage-backend-legacy";
 import AsyncStorageFactory, {
-  AsyncStorage
+  AsyncStorage,
 } from "@react-native-community/async-storage";
 
 type StorageModel = { [key in symbol | number | string]: string };
@@ -20,7 +20,11 @@ const createStorage = (
   getItem: asyncStorage.get.bind(asyncStorage),
   setItem: asyncStorage.set.bind(asyncStorage),
   removeItem: asyncStorage.remove.bind(asyncStorage),
-  clear: asyncStorage.clearStorage.bind(asyncStorage)
+  clear: asyncStorage.clearStorage.bind(asyncStorage),
 });
 
 export const storage = createStorage(defaultLegacyStorage);
+
+export const platformInfo: Adapters["platformInfo"] = {
+  name: "ReactNative",
+};

--- a/packages/platform-adapters-toutiao/src/index.ts
+++ b/packages/platform-adapters-toutiao/src/index.ts
@@ -1,4 +1,10 @@
+import { Adapters } from "@leancloud/adapter-types";
+
 export * from "./storage";
 export * from "./websocket";
 export * from "./http";
 export * from "./auth";
+
+export const platformInfo: Adapters["platformInfo"] = {
+  name: "Toutiao",
+};

--- a/packages/platform-adapters-weapp/src/index.ts
+++ b/packages/platform-adapters-weapp/src/index.ts
@@ -1,6 +1,11 @@
 import "miniprogram-api-typings";
+import { Adapters } from "@leancloud/adapter-types";
 
 export * from "./auth";
 export * from "./storage";
 export * from "./http";
 export * from "./websocket";
+
+export const platformInfo: Adapters["platformInfo"] = {
+  name: "Weapp",
+};


### PR DESCRIPTION
support to override the userAgent at runtime。原因是 

1. UA 是平台区别的一部分，应该从 SDK 里移出来
2. 像 React Native 等现在用 core + adapters 用法的，没有 bundle 这个环节了
3. 提供标准 API 来实现 https://github.com/leancloud/leanengine-node-sdk/blob/master/lib/storage-extra.js#L29