### PR TITLE
feat: abort request

### DIFF
--- a/packages/adapter-types/types.d.ts
+++ b/packages/adapter-types/types.d.ts
@@ -5,28 +5,31 @@ export interface PlatformInfo {
   userAgent?: string;
 }
 
+export type HTTPMethod =
+  | "OPTIONS"
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "TRACE"
+  | "CONNECT";
 export interface ProgressEvent {
   loaded: number;
   percent?: number;
   total?: number;
 }
-export interface UploadOptions {
+export interface RequestOptions {
+  method?: HTTPMethod;
   headers?: Record<string, string>;
   data?: Record<string, string>;
   onprogress?: (event: ProgressEvent) => void;
+  signal?: {
+    onabort: () => any;
+    addEventListener: (type: string, listener: () => any) => any;
+  };
 }
-interface RequestOptions extends UploadOptions {
-  method?:
-    | "OPTIONS"
-    | "GET"
-    | "HEAD"
-    | "POST"
-    | "PUT"
-    | "DELETE"
-    | "TRACE"
-    | "CONNECT";
-}
-interface Response {
+export interface Response {
   status?: number;
   ok?: boolean;
   headers?: object;
@@ -54,7 +57,7 @@ export declare type AsyncStorage = {
 };
 export declare type Storage = SyncStorage | AsyncStorage;
 
-interface WebSocket {
+export interface WebSocket {
   addEventListener(
     event: string,
     handler: (...args: any[]) => any,
@@ -83,7 +86,7 @@ export interface Adapters {
   upload: (
     url: string,
     file: FormDataPart,
-    options?: UploadOptions
+    options?: RequestOptions
   ) => Promise<Response>;
   storage: Storage;
   WebSocket: {

--- a/packages/adapter-types/types.d.ts
+++ b/packages/adapter-types/types.d.ts
@@ -19,15 +19,17 @@ export interface ProgressEvent {
   percent?: number;
   total?: number;
 }
+export interface AbortSignal {
+  readonly aborted: boolean;
+  onabort: () => any;
+  addEventListener: (type: string, listener: () => any) => any;
+}
 export interface RequestOptions {
   method?: HTTPMethod;
   headers?: Record<string, string>;
   data?: Record<string, string>;
   onprogress?: (event: ProgressEvent) => void;
-  signal?: {
-    onabort: () => any;
-    addEventListener: (type: string, listener: () => any) => any;
-  };
+  signal?: AbortSignal;
 }
 export interface Response {
   status?: number;

--- a/packages/adapter-utils/README.md
+++ b/packages/adapter-utils/README.md
@@ -1,0 +1,7 @@
+# `@leancloud/adapter-utils`
+
+## Usage
+
+```
+const adapterUtils = require('@leancloud/adapter-utils');
+```

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@leancloud/adapter-utils",
+  "version": "1.0.0",
+  "description": "A set of utility functions commonly used by adapters",
+  "author": "Lee Yeh <lee55962698@gmail.com>",
+  "homepage": "https://github.com/leancloud/adapters#readme",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/leancloud/adapters.git"
+  },
+  "scripts": {
+    "build": "npm run clean && npm run compile",
+    "clean": "rm -rf ./lib",
+    "compile": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run build"
+  }
+}

--- a/packages/adapter-utils/src/errors.ts
+++ b/packages/adapter-utils/src/errors.ts
@@ -1,0 +1,3 @@
+export class AbortError extends Error {
+  name = 'AbortError';
+}

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './errors'

--- a/packages/adapter-utils/tsconfig.build.json
+++ b/packages/adapter-utils/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "target": "es5",
+    "outDir": "./lib"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/adapter-utils/tsconfig.json
+++ b/packages/adapter-utils/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/adapters-superagent/package.json
+++ b/packages/adapters-superagent/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run compile",
-    "clean": "rm -rf ./dist",
+    "clean": "rm -rf ./lib",
     "compile": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build"
   },

--- a/packages/adapters-superagent/package.json
+++ b/packages/adapters-superagent/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@leancloud/adapter-types": "^3.0.0",
+    "@leancloud/adapter-utils": "^1.0.0",
     "@types/superagent": "^4.1.7",
     "superagent": "^5.2.2"
   },

--- a/packages/adapters-superagent/src/index.ts
+++ b/packages/adapters-superagent/src/index.ts
@@ -15,7 +15,7 @@ export const request: Adapters["request"] = function (url, options = {}) {
   const { method = "GET", data, headers, onprogress, signal } = options;
 
   if (signal?.aborted) {
-    return Promise.reject(new AbortError("Signal is already aborted"));
+    return Promise.reject(new AbortError("Request aborted"));
   }
 
   const req = superagent(method, url);
@@ -51,7 +51,7 @@ export const upload: Adapters["upload"] = (url, file, options = {}) => {
   const { method = "POST", data, headers, onprogress, signal } = options;
 
   if (signal?.aborted) {
-    return Promise.reject(new AbortError("Signal is already aborted"));
+    return Promise.reject(new AbortError("Request aborted"));
   }
 
   const req = superagent(method, url).attach(file.field, file.data, file.name);

--- a/packages/adapters-superagent/src/index.ts
+++ b/packages/adapters-superagent/src/index.ts
@@ -1,14 +1,17 @@
 import { Adapters } from "@leancloud/adapter-types";
 import * as superagent from "superagent";
 
-export const request: Adapters["request"] = (url, options = {}) => {
-  const { method = "GET", data, headers, onprogress } = options;
+export const request: Adapters["request"] = function (url, options = {}) {
+  const { method = "GET", data, headers, onprogress, signal } = options;
   const req = superagent(method, url);
   if (headers) {
     req.set(headers);
   }
   if (onprogress) {
     req.on("progress", onprogress);
+  }
+  if (signal) {
+    signal.addEventListener("abort", req.abort);
   }
 
   return req
@@ -23,13 +26,13 @@ export const request: Adapters["request"] = (url, options = {}) => {
       status,
       ok,
       headers: header,
-      data: body
+      data: body,
     }));
 };
 
 export const upload: Adapters["upload"] = (url, file, options = {}) => {
-  const { data, headers, onprogress } = options;
-  const req = superagent("POST", url).attach(file.field, file.data, file.name);
+  const { method = "POST", data, headers, onprogress, signal } = options;
+  const req = superagent(method, url).attach(file.field, file.data, file.name);
   if (data) {
     req.field(data);
   }
@@ -38,6 +41,9 @@ export const upload: Adapters["upload"] = (url, file, options = {}) => {
   }
   if (onprogress) {
     req.on("progress", onprogress);
+  }
+  if (signal) {
+    signal.addEventListener("abort", req.abort);
   }
   return req
     .catch(error => {
@@ -50,6 +56,6 @@ export const upload: Adapters["upload"] = (url, file, options = {}) => {
       status,
       ok,
       headers: header,
-      data: body
+      data: body,
     }));
 };

--- a/packages/adapters-superagent/src/index.ts
+++ b/packages/adapters-superagent/src/index.ts
@@ -3,6 +3,11 @@ import * as superagent from "superagent";
 
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method = "GET", data, headers, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
+
   const req = superagent(method, url);
   if (headers) {
     req.set(headers);
@@ -32,6 +37,11 @@ export const request: Adapters["request"] = function (url, options = {}) {
 
 export const upload: Adapters["upload"] = (url, file, options = {}) => {
   const { method = "POST", data, headers, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
+
   const req = superagent(method, url).attach(file.field, file.data, file.name);
   if (data) {
     req.field(data);
@@ -45,6 +55,7 @@ export const upload: Adapters["upload"] = (url, file, options = {}) => {
   if (signal) {
     signal.addEventListener("abort", req.abort);
   }
+
   return req
     .catch(error => {
       if (error.response) {

--- a/packages/adapters-superagent/src/index.ts
+++ b/packages/adapters-superagent/src/index.ts
@@ -1,11 +1,21 @@
-import { Adapters } from "@leancloud/adapter-types";
+import { Adapters, Response } from "@leancloud/adapter-types";
+import { AbortError } from "@leancloud/adapter-utils";
 import * as superagent from "superagent";
+
+function convertResponse(res: superagent.Response): Response {
+  return {
+    ok: res.ok,
+    status: res.status,
+    headers: res.header,
+    data: res.body,
+  };
+}
 
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method = "GET", data, headers, onprogress, signal } = options;
 
   if (signal?.aborted) {
-    return Promise.reject(new Error("Request aborted"));
+    return Promise.reject(new AbortError("Signal is already aborted"));
   }
 
   const req = superagent(method, url);
@@ -15,31 +25,33 @@ export const request: Adapters["request"] = function (url, options = {}) {
   if (onprogress) {
     req.on("progress", onprogress);
   }
-  if (signal) {
-    signal.addEventListener("abort", req.abort);
-  }
 
-  return req
-    .send(data)
-    .catch(error => {
-      if (error.response) {
-        return error.response;
+  return new Promise(async (resolve, reject) => {
+    if (signal) {
+      signal.addEventListener("abort", () => {
+        reject(new AbortError("Request aborted"));
+        req.abort();
+      });
+    }
+    try {
+      const res = await req.send(data);
+      resolve(convertResponse(res));
+    } catch (err) {
+      const resErr = err as superagent.ResponseError;
+      if (resErr.response) {
+        resolve(convertResponse(resErr.response));
+      } else {
+        reject(err);
       }
-      throw error;
-    })
-    .then(({ status, ok, header, body }) => ({
-      status,
-      ok,
-      headers: header,
-      data: body,
-    }));
+    }
+  });
 };
 
 export const upload: Adapters["upload"] = (url, file, options = {}) => {
   const { method = "POST", data, headers, onprogress, signal } = options;
 
   if (signal?.aborted) {
-    return Promise.reject(new Error("Request aborted"));
+    return Promise.reject(new AbortError("Signal is already aborted"));
   }
 
   const req = superagent(method, url).attach(file.field, file.data, file.name);
@@ -52,21 +64,24 @@ export const upload: Adapters["upload"] = (url, file, options = {}) => {
   if (onprogress) {
     req.on("progress", onprogress);
   }
-  if (signal) {
-    signal.addEventListener("abort", req.abort);
-  }
 
-  return req
-    .catch(error => {
-      if (error.response) {
-        return error.response;
+  return new Promise(async (resolve, reject) => {
+    if (signal) {
+      signal.addEventListener("abort", () => {
+        reject(new AbortError("Request aborted"));
+        req.abort();
+      });
+    }
+    try {
+      const res = await req;
+      resolve(convertResponse(res));
+    } catch (err) {
+      const resErr = err as superagent.ResponseError;
+      if (resErr.response) {
+        resolve(convertResponse(resErr.response));
+      } else {
+        reject(err);
       }
-      throw error;
-    })
-    .then(({ status, ok, header, body }) => ({
-      status,
-      ok,
-      headers: header,
-      data: body,
-    }));
+    }
+  });
 };

--- a/packages/platform-adapters-alipay/src/http.ts
+++ b/packages/platform-adapters-alipay/src/http.ts
@@ -2,6 +2,11 @@ import { Adapters } from "@leancloud/adapter-types";
 
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method, data, headers, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
+
   return new Promise((resolve, reject) => {
     const task = my.request({
       method,
@@ -25,11 +30,16 @@ export const request: Adapters["request"] = function (url, options = {}) {
 
 export const upload: Adapters["upload"] = function (url, file, options = {}) {
   const { headers, data, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(
       new TypeError("File data must be an object like { uri: localPath }.")
     );
   }
+
   return new Promise((resolve, reject) => {
     const task = my.uploadFile({
       url,

--- a/packages/platform-adapters-alipay/src/http.ts
+++ b/packages/platform-adapters-alipay/src/http.ts
@@ -1,29 +1,30 @@
-import { Adapters, RequestOptions } from "@leancloud/adapter-types";
+import { Adapters } from "@leancloud/adapter-types";
 
-export const request: Adapters["request"] = function (
-  url,
-  { method, data, headers }: RequestOptions = {}
-) {
+export const request: Adapters["request"] = function (url, options = {}) {
+  const { method, data, headers, signal } = options;
   return new Promise((resolve, reject) => {
-    my.request({
+    const task = my.request({
       method,
       url,
       headers,
       data,
-      success: (res: any) => {
+      complete: (res: any) => {
+        if (!res.status) {
+          reject(new Error(res.errorMessage));
+          return;
+        }
         res.ok = !(res.status >= 400);
         resolve(res);
       },
-      fail: reject,
     });
+    if (signal) {
+      signal.addEventListener("abort", task.abort);
+    }
   });
-}
+};
 
-export const upload: Adapters["upload"] = function (
-  url,
-  file,
-  { headers, data, onprogress }: RequestOptions = {}
-) {
+export const upload: Adapters["upload"] = function (url, file, options = {}) {
+  const { headers, data, onprogress, signal } = options;
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(
       new TypeError("File data must be an object like { uri: localPath }.")
@@ -38,22 +39,24 @@ export const upload: Adapters["upload"] = function (
       formData: data,
       fileType: "image",
       success: (res: any) => {
-        res.ok = !(res.statusCode >= 400);
-        resolve(res);
+        resolve({
+          ok: !(res.statusCode >= 400),
+          status: res.statusCode,
+          headers: res.header,
+          data: res.data,
+        });
       },
       fail: reject,
     });
-    const progressHandler = ({
-      progress,
-      totalBytesWritten,
-      totalBytesExpectedToWrite,
-    }: any) => {
-      onprogress?.({
-        percent: progress,
-        loaded: totalBytesWritten,
-        total: totalBytesExpectedToWrite,
-      });
+    if (signal) {
+      signal.addEventListener("abort", task.abort);
     }
-    task?.onProgressUpdate?.(progressHandler);
+    if (onprogress) {
+      task.onProgressUpdate((event: any) => onprogress({
+        loaded: event.totalBytesWritten,
+        total: event.totalBytesExpectedToWrite,
+        percent: event.progress,
+      }));
+    }
   });
-}
+};

--- a/packages/platform-adapters-baidu/src/http.ts
+++ b/packages/platform-adapters-baidu/src/http.ts
@@ -1,7 +1,12 @@
-import { Adapters, RequestOptions } from "@leancloud/adapter-types";
+import { Adapters } from "@leancloud/adapter-types";
 
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method, data, headers, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
+
   return new Promise((resolve, reject) => {
     const task = swan.request({
       url,
@@ -29,11 +34,16 @@ export const request: Adapters["request"] = function (url, options = {}) {
 
 export const upload: Adapters["upload"] = function (url, file, options = {}) {
   const { headers, data, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(
       new TypeError("File data must be an object like { uri: localPath }.")
     );
   }
+
   return new Promise((resolve, reject) => {
     const task = swan.uploadFile({
       url,

--- a/packages/platform-adapters-browser/package.json
+++ b/packages/platform-adapters-browser/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run compile",
-    "clean": "rm -rf ./dist",
+    "clean": "rm -rf ./lib",
     "compile": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build"
   },

--- a/packages/platform-adapters-node/package.json
+++ b/packages/platform-adapters-node/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run compile",
-    "clean": "rm -rf ./dist",
+    "clean": "rm -rf ./lib",
     "compile": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build"
   },

--- a/packages/platform-adapters-quickapp/src/index.ts
+++ b/packages/platform-adapters-quickapp/src/index.ts
@@ -1,7 +1,6 @@
 import {
   Adapters,
   RequestOptions,
-  UploadOptions
 } from "@leancloud/adapter-types";
 import { EventTarget } from "event-target-shim";
 
@@ -44,7 +43,7 @@ export const request: Adapters["request"] = (
 const uploadFile: Adapters["upload"] = (
   url,
   file,
-  { headers, data, onprogress }: UploadOptions = {}
+  { headers, data, onprogress }: RequestOptions = {}
 ) => {
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(

--- a/packages/platform-adapters-toutiao/src/http.ts
+++ b/packages/platform-adapters-toutiao/src/http.ts
@@ -2,6 +2,11 @@ import { Adapters, RequestOptions } from "@leancloud/adapter-types";
 
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method, data, headers, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
+
   return new Promise((resolve, reject) => {
     const task = tt.request({
       url,
@@ -29,11 +34,16 @@ export const request: Adapters["request"] = function (url, options = {}) {
 
 export const upload: Adapters["upload"] = function (url, file, options = {}) {
   const { headers, data, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(
       new TypeError("File data must be an object like { uri: localPath }.")
     );
   }
+
   return new Promise((resolve, reject) => {
     const task = tt.uploadFile({
       url,

--- a/packages/platform-adapters-toutiao/src/http.ts
+++ b/packages/platform-adapters-toutiao/src/http.ts
@@ -1,30 +1,34 @@
 import { Adapters, RequestOptions } from "@leancloud/adapter-types";
 
-export const request: Adapters["request"] = function (
-  url,
-  { method, data, headers }: RequestOptions = {}
-) {
+export const request: Adapters["request"] = function (url, options = {}) {
+  const { method, data, headers, signal } = options;
   return new Promise((resolve, reject) => {
-    tt.request({
+    const task = tt.request({
       url,
       method,
       header: headers,
       data,
-      success: (res: any) => {
-        res.status = res.statusCode;
-        res.ok = !(res.status >= 400);
-        resolve(res);
+      complete: (res: any) => {
+        if (!res.statusCode) {
+          reject(new Error(res.errMsg));
+          return;
+        }
+        resolve({
+          ok: !(res.statusCode >= 400),
+          status: res.statusCode,
+          headers: res.header,
+          data: res.data,
+        });
       },
-      fail: (res: any) => reject(new Error(res.errMsg)),
     });
+    if (signal) {
+      signal.addEventListener("abort", task.abort);
+    }
   });
-}
+};
 
-export const upload: Adapters["upload"] = function (
-  url,
-  file,
-  { headers, data, onprogress }: RequestOptions = {}
-) {
+export const upload: Adapters["upload"] = function (url, file, options = {}) {
+  const { headers, data, onprogress, signal } = options;
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(
       new TypeError("File data must be an object like { uri: localPath }.")
@@ -44,17 +48,15 @@ export const upload: Adapters["upload"] = function (
       },
       fail: (res: any) => reject(new Error(res.errMsg)),
     });
-    const progressHandler = ({
-      progress,
-      totalBytesSent,
-      totalBytesExpectedToSend,
-    }: any) => {
-      onprogress?.({
-        percent: progress,
-        loaded: totalBytesSent,
-        total: totalBytesExpectedToSend,
-      });
+    if (signal) {
+      signal.addEventListener("abort", task.abort);
     }
-    task?.onProgressUpdate?.(progressHandler);
+    if (onprogress) {
+      task.onProgressUpdate((event: any) => onprogress({
+        loaded: event.totalBytesSent,
+        total: event.totalBytesExpectedToSend,
+        percent: event.progress,
+      }));
+    }
   });
-}
+};

--- a/packages/platform-adapters-weapp/src/http.ts
+++ b/packages/platform-adapters-weapp/src/http.ts
@@ -2,6 +2,11 @@ import { Adapters, RequestOptions } from "@leancloud/adapter-types";
 
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method, data, headers, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
+
   return new Promise((resolve, reject) => {
     const task = wx.request({
       url,
@@ -29,11 +34,16 @@ export const request: Adapters["request"] = function (url, options = {}) {
 
 export const upload: Adapters["upload"] = function (url, file, options = {}) {
   const { headers, data, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(
       new TypeError("File data must be an object like { uri: localPath }.")
     );
   }
+
   return new Promise((resolve, reject) => {
     const task = wx.uploadFile({
       url,


### PR DESCRIPTION
### 改动说明
本次更新没有影响兼容性的改动。

#### adapter-types
- 移除 `UploadOptions` ，request / upload 统一使用 `RequestOptions`
   之前 `RequestOptions` 只比 `UploadOptions` 多了 `method` 字段，现在上传时也可指定 HTTP Method ，增加适用场景。
- 为 `RequestOptions` 添加 `signal` 字段，可通过传入 AbortSignal 中途取消 request / upload

#### SuperAgent Adapters
- 支持中途取消 request / upload
- 上传时可指定 HTTP Method ，默认为 `POST`

#### 各小程序 Adapters
- 修复返回 400 / 404 / 500 等状态码时抛异常的问题
   返回 400 等状态码不算是请求发送失败，应将响应数据原样交由 SDK 处理。之前直接抛异常的实现不符合该设计，修改后仅在请求发送失败时抛异常
- 支持中途取消 request / upload

### 其他
react-native 未更新，quick-app 为了能编译把 `UploadOptions` 替换为 `RequestOptions`