### PR TITLE
feat(mini-app): throw AbortError when aborted

### DIFF
--- a/packages/adapter-types/types.d.ts
+++ b/packages/adapter-types/types.d.ts
@@ -35,7 +35,7 @@ export interface Response {
   status?: number;
   ok?: boolean;
   headers?: object;
-  data?: any;
+  data?: object;
 }
 export interface FormDataPart {
   field: string;

--- a/packages/adapter-types/types.d.ts
+++ b/packages/adapter-types/types.d.ts
@@ -35,7 +35,7 @@ export interface Response {
   status?: number;
   ok?: boolean;
   headers?: object;
-  data?: object;
+  data?: any;
 }
 export interface FormDataPart {
   field: string;

--- a/packages/platform-adapters-alipay/package.json
+++ b/packages/platform-adapters-alipay/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@leancloud/adapter-types": "^4.0.0",
+    "@leancloud/adapter-utils": "^1.0.0",
     "base64-arraybuffer": "^0.2.0",
     "event-target-shim": "^5.0.1"
   }

--- a/packages/platform-adapters-alipay/src/http.ts
+++ b/packages/platform-adapters-alipay/src/http.ts
@@ -1,4 +1,5 @@
 import { Adapters } from "@leancloud/adapter-types";
+import { AbortError } from "@leancloud/adapter-utils";
 
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method, data, headers, signal } = options;
@@ -13,17 +14,24 @@ export const request: Adapters["request"] = function (url, options = {}) {
       url,
       headers,
       data,
-      complete: (res: any) => {
-        if (!res.status) {
-          reject(new Error(res.errorMessage));
-          return;
+      complete: (res) => {
+        if (res.status) {
+          resolve({
+            ok: !(res.status >= 400),
+            status: res.status,
+            headers: res.headers,
+            data: res.data,
+          });
+        } else {
+          reject(new Error(`${res.error}: ${res.errorMessage}`));
         }
-        res.ok = !(res.status >= 400);
-        resolve(res);
       },
     });
     if (signal) {
-      signal.addEventListener("abort", task.abort);
+      signal.addEventListener("abort", () => {
+        reject(new AbortError("Request aborted"));
+        task.abort();
+      });
     }
   });
 };
@@ -32,7 +40,7 @@ export const upload: Adapters["upload"] = function (url, file, options = {}) {
   const { headers, data, onprogress, signal } = options;
 
   if (signal?.aborted) {
-    return Promise.reject(new Error("Request aborted"));
+    return Promise.reject(new AbortError("Request aborted"));
   }
   if (!(file && file.data && file.data.uri)) {
     return Promise.reject(
@@ -48,25 +56,30 @@ export const upload: Adapters["upload"] = function (url, file, options = {}) {
       fileName: file.field,
       formData: data,
       fileType: "image",
-      success: (res: any) => {
+      success: (res) => {
         resolve({
-          ok: !(res.statusCode >= 400),
+          ok: !(res.statusCode! >= 400),
           status: res.statusCode,
           headers: res.header,
           data: res.data,
         });
       },
-      fail: reject,
+      fail: (res) => reject(new Error(`${res.error}: ${res.errorMessage}`)),
     });
     if (signal) {
-      signal.addEventListener("abort", task.abort);
+      signal.addEventListener("abort", () => {
+        reject(new AbortError("Request aborted"));
+        task.abort();
+      });
     }
     if (onprogress) {
-      task.onProgressUpdate((event: any) => onprogress({
-        loaded: event.totalBytesWritten,
-        total: event.totalBytesExpectedToWrite,
-        percent: event.progress,
-      }));
+      task.onProgressUpdate((event) =>
+        onprogress({
+          loaded: event.totalBytesWritten,
+          total: event.totalBytesExpectedToWrite,
+          percent: event.progress,
+        })
+      );
     }
   });
 };

--- a/packages/platform-adapters-alipay/src/http.ts
+++ b/packages/platform-adapters-alipay/src/http.ts
@@ -1,6 +1,19 @@
 import { Adapters } from "@leancloud/adapter-types";
 import { AbortError } from "@leancloud/adapter-utils";
 
+function parseResponseData(data: any): object | undefined {
+  switch (typeof data) {
+    case 'undefined':
+      return void 0;
+    case 'object':
+      return data;
+    case 'string':
+      return JSON.parse(data);
+    default:
+      throw new Error("Unsupported response data format");
+  }
+}
+
 export const request: Adapters["request"] = function (url, options = {}) {
   const { method, data, headers, signal } = options;
 
@@ -20,7 +33,7 @@ export const request: Adapters["request"] = function (url, options = {}) {
             ok: !(res.status >= 400),
             status: res.status,
             headers: res.headers,
-            data: res.data,
+            data: parseResponseData(res.data),
           });
         } else {
           reject(new Error(`${res.error}: ${res.errorMessage}`));
@@ -61,7 +74,7 @@ export const upload: Adapters["upload"] = function (url, file, options = {}) {
           ok: !(res.statusCode! >= 400),
           status: res.statusCode,
           headers: res.header,
-          data: res.data,
+          data: parseResponseData(res.data),
         });
       },
       fail: (res) => reject(new Error(`${res.error}: ${res.errorMessage}`)),

--- a/packages/platform-adapters-alipay/src/my.d.ts
+++ b/packages/platform-adapters-alipay/src/my.d.ts
@@ -1,1 +1,129 @@
-declare const my: any;
+declare const my: my.AlipayStatic;
+
+declare namespace my {
+  interface AlipayStatic {
+    request(option: RequestOption): RequestTask;
+    uploadFile(option: UploadOption): UploadTask;
+    getAuthCode(option: GetAuthCodeOption): void;
+    getStorageSync(option: { key: string }): { data: string | object };
+    setStorageSync(option: { key: string; data: string | object }): void;
+    removeStorageSync(option: { key: string }): void;
+    clearStorageSync(): void;
+    connectSocket(option: ConnectSocketOption): void;
+    sendSocketMessage(option: SendSocketMessageOption): void;
+    closeSocket(/* omit option */): void;
+    onSocketOpen(listener: Function): void;
+    onSocketError(listener: Function): void;
+    onSocketClose(listener: Function): void;
+    onSocketMessage(listener: OnSocketMessageListener): void;
+    offSocketOpen(listener?: Function): void;
+    offSocketError(listener?: Function): void;
+    offSocketClose(listener?: Function): void;
+    offSocketMessage(listener?: OnSocketMessageListener): void;
+  }
+
+  interface RequestOption {
+    url: string;
+    headers?: object;
+    method?: string;
+    data?: object | ArrayBuffer;
+    timeout?: number;
+    dataType?: string;
+    success?: RequestCallback;
+    fail?: RequestCallback;
+    complete: RequestCallback;
+  }
+
+  interface RequestCallback {
+    (res: Response): void;
+  }
+
+  interface ResponseError {
+    error?: number;
+    errorMessage?: string;
+  }
+
+  interface Response extends ResponseError {
+    status?: number;
+    headers?: object;
+    data?: string;
+  }
+
+  interface RequestTask {
+    abort(): void;
+  }
+
+  interface UploadOption {
+    url: string;
+    filePath: string;
+    fileName: string;
+    fileType: "image" | "video" | "audio";
+    hideLoading?: boolean;
+    header?: object;
+    formData?: object;
+    success?: UploadCallback;
+    fail?: UploadCallback;
+    complete?: UploadCallback;
+  }
+
+  interface UploadCallback {
+    (res: UploadResponse): void;
+  }
+
+  interface UploadResponse extends ResponseError {
+    statusCode?: number;
+    header?: object;
+    data?: string;
+  }
+
+  interface UploadTask {
+    abort(): void;
+    onProgressUpdate(listener: (event: UploadProgressEvent) => void): void;
+  }
+
+  interface UploadProgressEvent {
+    progress: number;
+    totalBytesWritten: number;
+    totalBytesExpectedToWrite: number;
+  }
+
+  type AuthScope = "auth_base" | "auth_user" | "auth_zhima";
+
+  interface GetAuthCodeOption {
+    scopes?: AuthScope | AuthScope[];
+    success?: GetAuthCodeCallback;
+    fail?: any;
+    complete?: any;
+  }
+
+  interface GetAuthCodeCallback {
+    (data: AuthCodeData): void;
+  }
+
+  interface AuthCodeData {
+    authCode: string;
+    authErrorScopes: Record<string, any>;
+    authSuccessScopes: AuthScope[];
+  }
+
+  interface ConnectSocketOption {
+    url: string;
+    data?: object;
+    header?: object;
+    success?: Function;
+    fail?: Function;
+    complete?: Function;
+  }
+
+  interface SendSocketMessageOption {
+    data: string;
+    isBuffer?: boolean;
+    success?: Function;
+    fail?: Function;
+    complete?: Function;
+  }
+
+  interface OnSocketMessageListener {
+    (event: { data: string | ArrayBuffer, isBuffer: boolean }): void;
+  }
+}

--- a/packages/platform-adapters-alipay/src/my.d.ts
+++ b/packages/platform-adapters-alipay/src/my.d.ts
@@ -31,7 +31,7 @@ declare namespace my {
     dataType?: string;
     success?: RequestCallback;
     fail?: RequestCallback;
-    complete: RequestCallback;
+    complete?: RequestCallback;
   }
 
   interface RequestCallback {

--- a/packages/platform-adapters-alipay/src/my.d.ts
+++ b/packages/platform-adapters-alipay/src/my.d.ts
@@ -9,17 +9,17 @@ declare namespace my {
     setStorageSync(option: { key: string; data: string | object }): void;
     removeStorageSync(option: { key: string }): void;
     clearStorageSync(): void;
-    connectSocket(option: ConnectSocketOption): void;
-    sendSocketMessage(option: SendSocketMessageOption): void;
+    connectSocket(option: SocketConnectOption): void;
+    sendSocketMessage(option: SocketSendMessageOption): void;
     closeSocket(/* omit option */): void;
     onSocketOpen(listener: Function): void;
     onSocketError(listener: Function): void;
     onSocketClose(listener: Function): void;
-    onSocketMessage(listener: OnSocketMessageListener): void;
+    onSocketMessage(listener: SocketOnMessageListener): void;
     offSocketOpen(listener?: Function): void;
     offSocketError(listener?: Function): void;
     offSocketClose(listener?: Function): void;
-    offSocketMessage(listener?: OnSocketMessageListener): void;
+    offSocketMessage(listener?: SocketOnMessageListener): void;
   }
 
   interface RequestOption {
@@ -106,7 +106,7 @@ declare namespace my {
     authSuccessScopes: AuthScope[];
   }
 
-  interface ConnectSocketOption {
+  interface SocketConnectOption {
     url: string;
     data?: object;
     header?: object;
@@ -115,7 +115,7 @@ declare namespace my {
     complete?: Function;
   }
 
-  interface SendSocketMessageOption {
+  interface SocketSendMessageOption {
     data: string;
     isBuffer?: boolean;
     success?: Function;
@@ -123,7 +123,7 @@ declare namespace my {
     complete?: Function;
   }
 
-  interface OnSocketMessageListener {
+  interface SocketOnMessageListener {
     (event: { data: string | ArrayBuffer, isBuffer: boolean }): void;
   }
 }

--- a/packages/platform-adapters-alipay/src/storage.ts
+++ b/packages/platform-adapters-alipay/src/storage.ts
@@ -3,7 +3,7 @@ import { Adapters } from "@leancloud/adapter-types";
 export const storage: Adapters["storage"] = {
   getItem(key) {
     const { data } = my.getStorageSync({ key });
-    return data;
+    return data as string;
   },
 
   setItem(key, value) {


### PR DESCRIPTION
### 说明
相关 PR ：#14

- 继续更新小程序相关的部分
- ~~`Response.data` 由 `object` 放宽为 `any` ，以支持返回纯文本、二进制数据的情况。~~
   ~~如果需要 `object` 类型的数据但返回的是 `string` ，转换的操作应该在 SDK 中完成，各 Adapter 只需要原样返回即可。~~
   ~~（现各 Adapter 都支持 `Content-Type` 为 `application/json` 时自动将 `string` 转换为 `object` ，但此功能对于 Adapter 不是必须的）~~