### PR TITLE
feat(RN): downgrade @react-native-community/async-storage to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1142,16 +1142,11 @@
       }
     },
     "@react-native-community/async-storage": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-2.0.0-rc.3.tgz",
-      "integrity": "sha512-inAIetMy5HwKA9vZGKrVzXA+Uxr7EzKy/IG+DsWTISEqQMwl0b3JWufRZHk3Xj7MqMSn8PdBDM/mmk5tY15qLg=="
-    },
-    "@react-native-community/async-storage-backend-legacy": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage-backend-legacy/-/async-storage-backend-legacy-2.0.0-rc.3.tgz",
-      "integrity": "sha512-nWH8GDMxQ93Ayx1ZhQWZkH70yz8e2mGOeiF7xY7h1/GNxl0taWJrjaWRaHb9FNcC7xe42c33hIjJBRZe0cMlFQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.11.0.tgz",
+      "integrity": "sha512-Pq9LlmvtCEKAGdkyrgTcRxNh2fnHFykEj2qnRYijOl1pDIl2MkD5IxaXu5eOL0wgOtAl4U//ff4z40Td6XR5rw==",
       "requires": {
-        "@react-native-community/async-storage": "^2.0.0-rc.3"
+        "deep-assign": "^3.0.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -2409,6 +2404,14 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "deep-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "deep-freeze": {
       "version": "0.0.1",
@@ -4129,8 +4132,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-plain-obj": {
       "version": "1.1.0",

--- a/packages/platform-adapters-react-native/package.json
+++ b/packages/platform-adapters-react-native/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@leancloud/adapter-types": "^4.0.0",
     "@leancloud/platform-adapters-browser": "^1.2.0",
-    "@react-native-community/async-storage": "^2.0.0-rc.2",
-    "@react-native-community/async-storage-backend-legacy": "^2.0.0-rc.2"
+    "@react-native-community/async-storage": "^1.11.0"
   }
 }

--- a/packages/platform-adapters-react-native/src/index.ts
+++ b/packages/platform-adapters-react-native/src/index.ts
@@ -1,29 +1,9 @@
 import { Adapters } from "@leancloud/adapter-types";
 export * from "@leancloud/platform-adapters-browser";
 
-import LegacyStorage from "@react-native-community/async-storage-backend-legacy";
-import AsyncStorageFactory, {
-  AsyncStorage,
-} from "@react-native-community/async-storage";
+import AsyncStorage from '@react-native-community/async-storage';
 
-type StorageModel = { [key in symbol | number | string]: string };
-
-const defaultLegacyStorage = AsyncStorageFactory.create(
-  new LegacyStorage<StorageModel>(),
-  {}
-);
-
-const createStorage = (
-  asyncStorage: AsyncStorage<StorageModel, any>
-): Adapters["storage"] => ({
-  async: true,
-  getItem: asyncStorage.get.bind(asyncStorage),
-  setItem: asyncStorage.set.bind(asyncStorage),
-  removeItem: asyncStorage.remove.bind(asyncStorage),
-  clear: asyncStorage.clearStorage.bind(asyncStorage),
-});
-
-export const storage = createStorage(defaultLegacyStorage);
+export const storage = {...AsyncStorage, async: true };
 
 export const platformInfo: Adapters["platformInfo"] = {
   name: "ReactNative",


### PR DESCRIPTION
to make it work with Expo(v38)

原计划是直接一步到位升级到 @react-native-community/async-storage v2。但是 v2 rc 了半年迟迟不发布 stable 版本，同时 @react-native-community/async-storage v1 也已经被集成到 Expo Client 了。因此我们先退回到 v1 保证在 Expo 中能直接用。