### PR TITLE
feat(node): stream request data

### DIFF
--- a/packages/platform-adapters-node/package.json
+++ b/packages/platform-adapters-node/package.json
@@ -31,12 +31,16 @@
   },
   "dependencies": {
     "@leancloud/adapter-types": "^5.0.0",
-    "@leancloud/adapters-superagent": "^1.4.3",
+    "@leancloud/adapter-utils": "^1.2.2",
     "@types/ws": "^7.2.2",
     "localstorage-memory": "^1.0.2",
+    "superagent": "^8.0.9",
     "ws": "^5.2.2"
   },
   "bugs": {
     "url": "https://github.com/leancloud/adapters/issues"
+  },
+  "devDependencies": {
+    "@types/superagent": "^4.1.16"
   }
 }

--- a/packages/platform-adapters-node/src/adapters-superagent.ts
+++ b/packages/platform-adapters-node/src/adapters-superagent.ts
@@ -1,0 +1,104 @@
+import { Readable } from "stream";
+import { Adapters, Response } from "@leancloud/adapter-types";
+import { AbortError } from "@leancloud/adapter-utils";
+import * as superagent from "superagent";
+
+function convertResponse(res: superagent.Response): Response {
+  return {
+    ok: res.ok,
+    status: res.status,
+    headers: res.header,
+    data: res.body,
+  };
+}
+
+export function sendReadableData(
+  req: superagent.SuperAgentRequest,
+  data: Readable
+) {
+  return new Promise<superagent.Response>((resolve, reject) => {
+    req.on("response", resolve);
+    req.on("error", reject);
+    data.pipe(req as any);
+  });
+}
+
+export const request: Adapters["request"] = async (url, options = {}) => {
+  const { method = "GET", data, headers, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    throw new AbortError("Request aborted");
+  }
+
+  const req = superagent(method, url).ok(() => true);
+  if (headers) {
+    req.set(headers);
+  }
+  if (onprogress) {
+    req.on("progress", onprogress);
+  }
+
+  let aborted = false;
+  const onAbort = () => {
+    aborted = true;
+    req.abort();
+  };
+
+  signal?.addEventListener("abort", onAbort);
+
+  try {
+    const res =
+      data instanceof Readable
+        ? await sendReadableData(req, data)
+        : await req.send(data);
+    return convertResponse(res);
+  } catch (error) {
+    if (aborted) {
+      throw new AbortError("Request aborted");
+    }
+    throw error;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
+};
+
+export const upload: Adapters["upload"] = async (url, file, options = {}) => {
+  const { method = "POST", data, headers, onprogress, signal } = options;
+
+  if (signal?.aborted) {
+    throw new AbortError("Request aborted");
+  }
+
+  const req = superagent(method, url)
+    .ok(() => true)
+    .attach(file.field, file.data, file.name);
+  if (data) {
+    req.field(data);
+  }
+  if (headers) {
+    req.set(headers);
+  }
+  if (onprogress) {
+    req.on("progress", onprogress);
+  }
+
+  let aborted = false;
+  const onAbort = () => {
+    aborted = true;
+    req.abort();
+  };
+
+  signal?.addEventListener("abort", onAbort);
+
+  try {
+    const res = await req;
+    return convertResponse(res);
+  } catch (error) {
+    if (aborted) {
+      throw new AbortError("Request aborted");
+    }
+    throw error;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
+};

--- a/packages/platform-adapters-node/src/index.ts
+++ b/packages/platform-adapters-node/src/index.ts
@@ -8,4 +8,4 @@ export const platformInfo: Adapters["platformInfo"] = {
 };
 export const WebSocket: Adapters["WebSocket"] = WS;
 export const storage: Adapters["storage"] = localStorageMemory;
-export { request, upload } from "@leancloud/adapters-superagent";
+export { request, upload } from "./adapters-superagent";


### PR DESCRIPTION
node adapters 直接依赖 superagent，把之前 adapters-superagent 里的代码复制到 node adapters 下，再加上 stream 支持。